### PR TITLE
Changed children property from empty string to undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ export default class FileInput extends React.Component {
 
     return <div className="_react-file-reader-input"
                 onClick={this.triggerInput}>
-      <input {...this.props} children="" type="file"
+      <input {...this.props} children={undefined} type="file"
              onChange={this.handleChange} ref="_reactFileReaderInput"
              style={hiddenInputStyle}/>
 


### PR DESCRIPTION
Currently library returns `Warning: input is a void element tag and must not have children or use props.dangerouslySetInnerHTML. Check the render method of FileInput.` when using React 0.14 and specifying own children.
