### PR TITLE
removed reference to React.PropTypes (deprecated). added dependency for 'prop-types' and updated all prop-type references.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,15 +24,19 @@ var _reactDom = require('react-dom');
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var FileInput = (function (_React$Component) {
   _inherits(FileInput, _React$Component);
 
   _createClass(FileInput, null, [{
     key: 'propTypes',
     value: {
-      as: _react2['default'].PropTypes.oneOf(['binary', 'buffer', 'text', 'url']),
-      children: _react2['default'].PropTypes.any,
-      onChange: _react2['default'].PropTypes.func
+      as: _propTypes2['default'].oneOf(['binary', 'buffer', 'text', 'url']),
+      children: _propTypes2['default'].any,
+      onChange: _propTypes2['default'].func
     },
     enumerable: true
   }]);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-mocha": "^0.2.0",
     "mocha": "^2.2.5",
+    "prop-types": "^15.5.10",
     "react": "^15.0.0",
     "react-dom": "*"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-
+import PropTypes from 'prop-types';
 
 export default class FileInput extends React.Component {
   static propTypes = {
-    as: React.PropTypes.oneOf(['binary', 'buffer', 'text', 'url']),
-    children: React.PropTypes.any,
-    onChange: React.PropTypes.func,
+    as: PropTypes.oneOf(['binary', 'buffer', 'text', 'url']),
+    children: PropTypes.any,
+    onChange: PropTypes.func,
   }
   constructor(props) {
     // FileReader compatibility warning.


### PR DESCRIPTION
As of react 15.5.0, referencing `React.PropTypes` is now deprecated in favor of the `prop-types` library. The src has been updated to remove deprecation warnings.

Thanks in advance,
Gavin.