### PR TITLE
React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React file input component for complete control over styling and abstraction from file reading.",
   "main": "./lib/index.js",
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel": "^5.4.7",
@@ -15,12 +15,12 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-mocha": "^0.2.0",
     "mocha": "^2.2.5",
-    "react": "^15.0.0",
-    "react-dom": "^15.6.1"
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "react": "^15.0.0",
-    "react-dom": "*"
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
   },
   "scripts": {
     "build:lib": "babel --stage 0 src --out-dir lib",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,5 @@
   "bugs": {
     "url": "https://github.com/ngokevin/react-file-reader-input/issues"
   },
-  "homepage": "https://github.com/ngokevin/react-file-reader-input",
-  "dependencies": {
-    "karma": "^0.13.22"
-  }
+  "homepage": "https://github.com/ngokevin/react-file-reader-input"
 }


### PR DESCRIPTION
Fixing: https://github.com/ngokevin/react-file-reader-input/issues/17

React 16 is the version used in dev now, and the preferred version at runtime, although React 15 and React 16 are both accepted at runtime (see peerDependencies)..

I also removed a dependency on "karma" which was already present (and better placed) in the devDependencies.