### PR TITLE
Use `display: none` to hide input element

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,8 +111,7 @@ var FileInput = function (_React$Component) {
 
       var hiddenInputStyle = children ? {
         // If user passes in children, display children and hide input.
-        position: 'absolute',
-        top: '-9999px'
+        display: 'none'
       } : {};
 
       return React.createElement(

--- a/src/index.js
+++ b/src/index.js
@@ -76,8 +76,7 @@ export default class FileInput extends React.Component<Props> {
 
     const hiddenInputStyle = children ? {
       // If user passes in children, display children and hide input.
-      position: 'absolute',
-      top: '-9999px'
+      display: 'none'
     } : {};
 
     return (


### PR DESCRIPTION
It was previously hidden using `position: absolute` and `top: -9999px`.